### PR TITLE
specifying arch flag by argument

### DIFF
--- a/pywrapper/compile_with_cuda.bash
+++ b/pywrapper/compile_with_cuda.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+if [ -n "$1" ]
+then
+export EXT_FLAG="$1"
+fi
+sudo WITH_CUDA=ON $EXT_FLAG python setup.py install

--- a/pywrapper/compile_with_cuda.sh
+++ b/pywrapper/compile_with_cuda.sh
@@ -1,1 +1,0 @@
-sudo WITH_CUDA=ON python setup.py install

--- a/pywrapper/setup.py
+++ b/pywrapper/setup.py
@@ -93,7 +93,12 @@ def locate_cuda():
 
 # compiler_flags = ["-w","-std=c++11", "-march=native", "-ffast-math", "-fno-math-errno"]
 compiler_flags = ["-w","-std=c++11", "-march=native", "-ffast-math", "-fno-math-errno", "-O3"]
-nvcc_flags = ['-arch=sm_20', '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'", "-w","-std=c++11"]
+arch_flag = None
+if 'nvcc_arch' in os.environ:
+    arch_flag = '-arch='+os.environ['nvcc_arch']
+else:
+    arch_flag = '-arch=sm_20'
+nvcc_flags = [arch_flag, '--ptxas-options=-v', '-c', '--compiler-options', "'-fPIC'", "-w","-std=c++11"]
 include_dirs = ["../", numpy_include]
 depends = ["../includes/*.h"]
 sources = ["RangeLibc.pyx","../vendor/lodepng/lodepng.cpp"]


### PR DESCRIPTION
Now it is possible to specify nvcc flag `arch`:
`sudo WITH_CUDA=ON nvcc_arch=sm_61 python setup.py install`
or
`./compile_with_cuda.bash nvcc_arch=sm_61`