### PR TITLE
Update for python 3

### DIFF
--- a/pywrapper/RangeLibc.pyx
+++ b/pywrapper/RangeLibc.pyx
@@ -1,3 +1,5 @@
+# cython: language_level=2
+
 from libcpp cimport bool
 from libcpp.string cimport string
 from libcpp.vector cimport vector

--- a/pywrapper/setup.py
+++ b/pywrapper/setup.py
@@ -18,10 +18,10 @@ def check_for_flag(flag_str, truemsg=False, falsemsg=False):
 	    enabled = False
 
 	if enabled and not truemsg == False:
-		print truemsg
+		print(truemsg)
 	elif not enabled and not falsemsg == False:
-		print falsemsg
-		print "   $ sudo "+flag_str+"=ON python setup.py install"
+		print(falsemsg)
+		print("   $ sudo "+flag_str+"=ON python setup.py install")
 	return enabled
 
 use_cuda = check_for_flag("WITH_CUDA", \
@@ -29,11 +29,11 @@ use_cuda = check_for_flag("WITH_CUDA", \
 	"Compiling without CUDA support. To enable CUDA use:")
 trace    = check_for_flag("TRACE", \
 	"Compiling with trace enabled for Bresenham's Line", \
-	"Compiling without trace enabled for Bresenham's Line")
+	"Compiling without trace enabled for Bresenham's Line. To enable trace use:")
 
-print 
-print "--------------"
-print 
+print("")
+print("--------------")
+print("")
 
 # support for compiling in clang
 if platform.system().lower() == "darwin":
@@ -59,13 +59,13 @@ def locate_cuda():
     Starts by looking for the CUDAHOME env variable. If not found, everything
     is based on finding 'nvcc' in the PATH.
     """
-    # print os.environ
+    # print(os.environ)
     # first check if the CUDAHOME env variable is in use
     if os.path.isdir("/usr/local/cuda-7.5"):
-    	home = "/usr/local/cuda-7.5"
+        home = "/usr/local/cuda-7.5"
         nvcc = pjoin(home, 'bin', 'nvcc')
     elif os.path.isdir("/usr/local/cuda"):
-    	home = "/usr/local/cuda"
+        home = "/usr/local/cuda"
         nvcc = pjoin(home, 'bin', 'nvcc')
     elif 'CUDAHOME' in os.environ:
         home = os.environ['CUDAHOME']


### PR DESCRIPTION
Updates the python wrapper to work with python 3, retaining backwards compatibility with python 2. It can either be installed with:

`sudo python2 setup.py install` 
`sudo python3 setup.py install`

No changes are made to `test.py`, so that will not run at all. This is intentional: in its current state, `test.py` is fundamentally broken and prints erroneous warnings about the range calculations. Fixing this problem is more involved and should be addressed by a different PR.